### PR TITLE
Update the tarball version in devtools:install_local command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ BiocManager::install("SNPRelate")
 library(devtools)
 
 # install BITE V2 from source
-devtools::install_local("BITEV2_2.1.0.tar.gz")
+devtools::install_local("BITEV2_2.1.2.tar.gz")
 ```
 
 #### Dependencies


### PR DESCRIPTION
Update the install command to reflect the new version as **2.1.0** tarball doesn't exist anymore. Therefore,  `devtools::install_local("BITEV2_2.1.2.tar.gz")`